### PR TITLE
Bytes

### DIFF
--- a/basex.go
+++ b/basex.go
@@ -38,12 +38,8 @@ func isAsciiPrintable(s string) bool {
 	return true
 }
 
-// Encode converts the big integer to alpha id (an alphanumeric id with mixed cases)
-func Encode(s string) (string, error) {
-	//numeric validation
-	if !isValidNumeric(s) {
-		return "", errors.New("Encode string is not a valid numeric")
-	}
+// encode a big integer
+func encodeInt(remaining *big.Int) (string, error) {
 	var result []byte
 	var index int
 	var strVal string
@@ -54,9 +50,6 @@ func Encode(s string) (string, error) {
 	d := big.NewInt(0)
 
 	exponent := 1
-
-	remaining := big.NewInt(0)
-	remaining.SetString(s, 10)
 
 	for remaining.Cmp(big.NewInt(0)) != 0 {
 		a.Exp(base, big.NewInt(int64(exponent)), nil) //16^1 = 16
@@ -78,11 +71,24 @@ func Encode(s string) (string, error) {
 	return string(reverse(result)), nil
 }
 
-// Decode converts the alpha id to big integer
-func Decode(s string) (string, error) {
+// Encode converts the big integer to alpha id (an alphanumeric id with mixed cases)
+func Encode(s string) (string, error) {
+	//numeric validation
+	if !isValidNumeric(s) {
+		return "", errors.New("Encode string is not a valid numeric")
+	}
+
+	remaining := big.NewInt(0)
+	remaining.SetString(s, 10)
+
+	return encodeInt(remaining)
+}
+
+// decodeInt converts the alpha id to int
+func decodeInt(s string) (*big.Int, error) {
 	//Validate if given string is valid
 	if !isAsciiPrintable(s) {
-		return "", errors.New("Decode string is not valid.[a-z, A_Z, 0-9] only allowed")
+		return nil, errors.New("Decode string is not valid.[a-z, A_Z, 0-9] only allowed")
 	}
 	//reverse it, coz its already reversed!
 	chars2 := reverse([]byte(s))
@@ -109,6 +115,15 @@ func Decode(s string) (string, error) {
 		b = b.Mul(intermed, a)
 		bi = bi.Add(bi, b)
 		exponent = exponent + 1
+	}
+	return bi, nil
+}
+
+// Decode converts the alpha id to big integer
+func Decode(s string) (string, error) {
+	bi, err := decodeInt(s)
+	if err != nil {
+		return "", err
 	}
 	return bi.String(), nil
 }

--- a/basex.go
+++ b/basex.go
@@ -94,6 +94,16 @@ func Encode(s string) (string, error) {
 	return encodeInt(remaining)
 }
 
+// EncodeBytes converts a byte buffer to an alpha id (an alphanumeric id with mixed cases)
+// Note that it does not pad the result with zeroes,
+// so {0,0,255} encodes the same as {255}
+func EncodeBytes(b []byte) (string, error) {
+	i := big.NewInt(0)
+	i.SetBytes(b)
+
+	return encodeInt(i)
+}
+
 // decodeInt converts the alpha id to int
 func decodeInt(s string) (*big.Int, error) {
 	//Validate if given string is valid
@@ -123,10 +133,25 @@ func decodeInt(s string) (*big.Int, error) {
 // Decode converts the alpha id to big integer
 func Decode(s string) (string, error) {
 	bi, err := decodeInt(s)
+
 	if err != nil {
 		return "", err
 	}
+
 	return bi.String(), nil
+}
+
+// Decode converts the alpha id to a byte buffer representing the original big integer.
+// It might not restitute the buffer as the one passed to EncodeBytes
+// as heading zeroes are trimmed.
+func DecodeBytes(s string) ([]byte, error) {
+	bi, err := decodeInt(s)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return bi.Bytes(), nil
 }
 
 func reverse(bs []byte) []byte {

--- a/basex.go
+++ b/basex.go
@@ -12,10 +12,20 @@ import (
 var (
 	dictionary = []byte{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'}
 	base       *big.Int
+	dictMap    map[byte]*big.Int
 )
 
 func init() {
 	base = big.NewInt(int64(len(dictionary)))
+
+	//for efficiency, make a map
+	dictMap = make(map[byte]*big.Int)
+
+	j := 0
+	for _, val := range dictionary {
+		dictMap[val] = big.NewInt(int64(j))
+		j = j + 1
+	}
 }
 
 //checks if given string is a valid numeric
@@ -92,15 +102,6 @@ func decodeInt(s string) (*big.Int, error) {
 	}
 	//reverse it, coz its already reversed!
 	chars2 := reverse([]byte(s))
-
-	//for efficiency, make a map
-	dictMap := make(map[byte]*big.Int)
-
-	j := 0
-	for _, val := range dictionary {
-		dictMap[val] = big.NewInt(int64(j))
-		j = j + 1
-	}
 
 	bi := big.NewInt(0)
 


### PR DESCRIPTION
Here are the EncodeBytes and DecodeBytes functions I was talking about. These are proposals. More specifically, I'm not sure the meaning of the funcs should not be changed, take a look at the "failing" tests -> a given input won't give the same if passed in Encode then Decode, when there are "leading zeroes". Thinking of it, the same is true of your initial funcs, but it feels natural that "0010" -> some_hash -> "10" whereas on bytes buffers, it's... sort of strange. Meanwhile, the first 2 commits are still general optimizations, you might want to merge those anyway (c7484f6 and dffbeba).
