### PR TITLE
Int

### DIFF
--- a/basex.go
+++ b/basex.go
@@ -38,12 +38,8 @@ func isAsciiPrintable(s string) bool {
 	return true
 }
 
-// Encode converts the big integer to alpha id (an alphanumeric id with mixed cases)
-func Encode(s string) (string, error) {
-	//numeric validation
-	if !isValidNumeric(s) {
-		return "", errors.New("Encode string is not a valid numeric")
-	}
+// encode a big integer
+func encodeInt(remaining *big.Int) (string, error) {
 	var result []byte
 	var index int
 	var strVal string
@@ -54,9 +50,6 @@ func Encode(s string) (string, error) {
 	d := big.NewInt(0)
 
 	exponent := 1
-
-	remaining := big.NewInt(0)
-	remaining.SetString(s, 10)
 
 	for remaining.Cmp(big.NewInt(0)) != 0 {
 		a.Exp(base, big.NewInt(int64(exponent)), nil) //16^1 = 16
@@ -78,11 +71,24 @@ func Encode(s string) (string, error) {
 	return string(reverse(result)), nil
 }
 
-// Decode converts the alpha id to big integer
-func Decode(s string) (string, error) {
+// Encode converts the big integer to alpha id (an alphanumeric id with mixed cases)
+func Encode(s string) (string, error) {
+	//numeric validation
+	if !isValidNumeric(s) {
+		return "", errors.New("Encode string is not a valid numeric")
+	}
+
+	remaining := big.NewInt(0)
+	remaining.SetString(s, 10)
+
+	return encodeInt(remaining)
+}
+
+// decodeInt converts the alpha id to int
+func decodeInt(s string) (*big.Int, error) {
 	//Validate if given string is valid
 	if !isAsciiPrintable(s) {
-		return "", errors.New("Decode string is not valid.[a-z, A_Z, 0-9] only allowed")
+		return nil, errors.New("Decode string is not valid.[a-z, A_Z, 0-9] only allowed")
 	}
 	//reverse it, coz its already reversed!
 	chars2 := reverse([]byte(s))
@@ -109,6 +115,15 @@ func Decode(s string) (string, error) {
 		b = b.Mul(intermed, a)
 		bi = bi.Add(bi, b)
 		exponent = exponent + 1
+	}
+	return bi, nil
+}
+
+// Decode converts the alpha id to big integer
+func Decode(s string) (string, error) {
+	bi, err := decodeInt(s)
+	if err != nil {
+		return "", err
 	}
 	return bi.String(), nil
 }

--- a/basex.go
+++ b/basex.go
@@ -12,10 +12,20 @@ import (
 var (
 	dictionary = []byte{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'}
 	base       *big.Int
+	dictMap    map[byte]*big.Int
 )
 
 func init() {
 	base = big.NewInt(int64(len(dictionary)))
+
+	//for efficiency, make a map
+	dictMap = make(map[byte]*big.Int)
+
+	j := 0
+	for _, val := range dictionary {
+		dictMap[val] = big.NewInt(int64(j))
+		j = j + 1
+	}
 }
 
 //checks if given string is a valid numeric
@@ -92,15 +102,6 @@ func decodeInt(s string) (*big.Int, error) {
 	}
 	//reverse it, coz its already reversed!
 	chars2 := reverse([]byte(s))
-
-	//for efficiency, make a map
-	dictMap := make(map[byte]*big.Int)
-
-	j := 0
-	for _, val := range dictionary {
-		dictMap[val] = big.NewInt(int64(j))
-		j = j + 1
-	}
 
 	bi := big.NewInt(0)
 

--- a/basex.go
+++ b/basex.go
@@ -48,7 +48,7 @@ func isAsciiPrintable(s string) bool {
 	return true
 }
 
-// encode a big integer
+// encodeInt encodes a big.Int integer, the value of remaining is changed to 0 during the process
 func encodeInt(remaining *big.Int) (string, error) {
 	var result []byte
 	var index int
@@ -81,6 +81,14 @@ func encodeInt(remaining *big.Int) (string, error) {
 	return string(reverse(result)), nil
 }
 
+// EncodeInt encodes a big.Int integer
+func EncodeInt(i *big.Int) (string, error) {
+	remaining := big.NewInt(0)
+	remaining.Set(i)
+
+	return encodeInt(remaining)
+}
+
 // Encode converts the big integer to alpha id (an alphanumeric id with mixed cases)
 func Encode(s string) (string, error) {
 	//numeric validation
@@ -94,8 +102,8 @@ func Encode(s string) (string, error) {
 	return encodeInt(remaining)
 }
 
-// decodeInt converts the alpha id to int
-func decodeInt(s string) (*big.Int, error) {
+// DecodeInt converts the alpha id to a bit.Int
+func DecodeInt(s string) (*big.Int, error) {
 	//Validate if given string is valid
 	if !isAsciiPrintable(s) {
 		return nil, errors.New("Decode string is not valid.[a-z, A_Z, 0-9] only allowed")
@@ -122,7 +130,7 @@ func decodeInt(s string) (*big.Int, error) {
 
 // Decode converts the alpha id to big integer
 func Decode(s string) (string, error) {
-	bi, err := decodeInt(s)
+	bi, err := DecodeInt(s)
 	if err != nil {
 		return "", err
 	}

--- a/basex_test.go
+++ b/basex_test.go
@@ -49,6 +49,10 @@ func TestBasexFailure(t *testing.T) {
 }
 
 func TestForLargeInputs(t *testing.T) {
+	if testing.Short() {
+		t.Logf("skipping large input test")
+		return
+	}
 	for i := 1000; i < 3000000; i++ {
 		encode, err := Encode(strconv.Itoa(i))
 		if err != nil {


### PR DESCRIPTION
I finally refactored my bytes branch, this "int" branch does only introduce EncodeInt and DecodeInt as public members. They are used internally by Encode and Decode, they basically do exactly the same thing but use raw *big.Int args/ret value instead of strings. I do have code that encodes/decodes big.Int that way, somewhere lost in there https://github.com/ufoot/vapor/ Additionnally, the various refactoring do speed up stuff (try the bench and the large input test).
