### PR TITLE
PassKey

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.5
+- 1.7
 - tip
 matrix:
   allow_failures:

--- a/basex.go
+++ b/basex.go
@@ -33,6 +33,7 @@ func init() {
 	}
 }
 
+//Init initialized baseX with a passKey
 func Init(pass string) {
 	dictionary, dictMap = encDictionary(pass)
 }
@@ -180,16 +181,23 @@ func (ms multiSorter) Less(i, j int) bool {
 }
 
 func encDictionary(passKey string) (nDictionary []byte, nDictMap map[byte]*big.Int) {
+	//Get SHA256 of the passKey
 	h := sha256.New()
 	h.Write([]byte(passKey))
 	sha := hex.EncodeToString(h.Sum(nil))
+
+	//If the length is less that dictionary, use 512
 	if len(sha) < len(dictionary) {
 		h = sha512.New()
 		h.Write([]byte(passKey))
 		sha = hex.EncodeToString(h.Sum(nil))
 	}
+
+	//truncate the sha to the size of dictionary
 	shaSlice := strings.Split(sha[:len(dictionary)], "")
-	items := make([]Item, 0)
+
+	//Sort sha, return the dictionary that is sorted based on sha
+	var items []Item
 	for k, char := range shaSlice {
 		i := Item{char, string(dictionary[k])}
 		items = append(items, i)
@@ -200,7 +208,6 @@ func encDictionary(passKey string) (nDictionary []byte, nDictMap map[byte]*big.I
 	for k, item := range items {
 		nDictionary[k] = byte(item.key[0])
 		nDictMap[byte(item.key[0])] = big.NewInt(int64(k))
-
 	}
 	return
 }

--- a/basex_test.go
+++ b/basex_test.go
@@ -92,6 +92,51 @@ func TestForLargeInputs(t *testing.T) {
 	}
 }
 
+func TestBasexPassDifers(t *testing.T) {
+	n := "12345"
+	pass := "baseXisAwesome@123"
+	pass2 := "aAbBcCdD1!2@3#"
+
+	enc, err := Encode(n)
+	if err != nil {
+		t.Errorf("Encode error:%q", err)
+	}
+
+	Init(pass)
+	passEnc, err := Encode(n)
+	if err != nil {
+		t.Errorf("Encode error:%q", err)
+	}
+	if passEnc == enc {
+		t.Errorf("Encoded values same with and without password for %s with pass %s", n, pass)
+	}
+
+	Init(pass2)
+	passEnc2, err := Encode(n)
+	if err != nil {
+		t.Errorf("Encode error:%q", err)
+	}
+	if passEnc2 == passEnc || passEnc2 == enc {
+		t.Errorf("Encoded values same with and without password for %s with pass %s", n, pass)
+	}
+}
+func TestBasexSuccessWithPass(t *testing.T) {
+	passwords := []string{
+		"aaaaaaaaaaa",
+		"baseXisAwesome@123",
+		"twofdsa33212889#$@",
+		"",
+		"1",
+		"123445",
+	}
+	for _, pass := range passwords {
+		t.Run("With Pass: "+pass, func(t *testing.T) {
+			Init(pass)
+			TestBasexSuccess(t)
+		})
+	}
+}
+
 func BenchmarkEncode(b *testing.B) {
 	s := "9007199254740989"
 	for n := 0; n < b.N; n++ {


### PR DESCRIPTION
Initialize basex with a pass key for encrypted encoding. 
Usage - 
`baseX.Init(passKey)` 

The logic for encryption is as shown in [this link](http://kvz.io/blog/2009/06/10/create-short-ids-with-php-like-youtube-or-tinyurl/)